### PR TITLE
[FEAT] 로그인/로그아웃 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,14 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//JWT
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -1,0 +1,28 @@
+package org.smartcampus.smartcampus_be.domain.member.Controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.LoginResponseDto;
+import org.smartcampus.smartcampus_be.domain.member.service.MemberService;
+import org.smartcampus.smartcampus_be.global.response.ApiResponse;
+import org.smartcampus.smartcampus_be.global.response.SuccessType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponseDto>> login(@RequestBody @Valid LoginRequestDto request) {
+        return ResponseEntity.ok(ApiResponse.success(SuccessType.LOGIN_SUCCESS, memberService.login(request)));
+    }
+}
+

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.smartcampus.smartcampus_be.domain.member.Controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
@@ -23,6 +24,11 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(@RequestBody @Valid LoginRequestDto request) {
         return ResponseEntity.ok(ApiResponse.success(SuccessType.LOGIN_SUCCESS, memberService.login(request)));
+    }
+
+    @PostMapping("/log-out")
+    public ResponseEntity<ApiResponse<String>> logout(HttpServletRequest request) {
+        return ResponseEntity.ok((ApiResponse<String>) ApiResponse.success(SuccessType.LOGOUT_SUCCESS));
     }
 }
 

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/LoginRequestDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/LoginRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 public class LoginRequestDto {
 
     @NotBlank(message = "아이디는 필수입니다.")
-    private String id;
+    private String username;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/LoginRequestDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/LoginRequestDto.java
@@ -1,0 +1,14 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    private String id;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/LoginResponseDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/LoginResponseDto.java
@@ -1,0 +1,10 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String accessToken;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Member.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Member.java
@@ -1,0 +1,32 @@
+package org.smartcampus.smartcampus_be.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false, unique = true)
+    private String memberId;  // 아이디
+
+    @Column(nullable = false)
+    private String password;  // 암호화된 비밀번호
+
+    @Column(nullable = false)
+    private String name; // 계정명
+
+    private String description; // 설명
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Member.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Member.java
@@ -16,7 +16,7 @@ public class Member {
     private Long id;
 
     @Column(name = "member_id", nullable = false, unique = true)
-    private String memberId;  // 아이디
+    private String username;  // 아이디
 
     @Column(nullable = false)
     private String password;  // 암호화된 비밀번호

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Role.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package org.smartcampus.smartcampus_be.domain.member.entity;
+
+public enum Role {
+    ADMIN, USER;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/repository/MemberRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByMemberId(String memberId);
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package org.smartcampus.smartcampus_be.domain.member.repository;
+
+import org.smartcampus.smartcampus_be.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByMemberId(String memberId);
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
 
     public LoginResponseDto login(LoginRequestDto request) {
 
-        Member member = memberRepository.findByMemberId(request.getId())
+        Member member = memberRepository.findByUsername(request.getUsername())
                             .orElseThrow(() -> new CustomException(ErrorType.LOGIN_FAILED));
 
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -1,0 +1,42 @@
+package org.smartcampus.smartcampus_be.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.LoginResponseDto;
+import org.smartcampus.smartcampus_be.domain.member.entity.Member;
+import org.smartcampus.smartcampus_be.domain.member.repository.MemberRepository;
+import org.smartcampus.smartcampus_be.global.common.jwt.JwtTokenProvider;
+import org.smartcampus.smartcampus_be.global.common.jwt.UserAuthentication;
+import org.smartcampus.smartcampus_be.global.exception.CustomException;
+import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    public LoginResponseDto login(LoginRequestDto request) {
+
+        Member member = memberRepository.findByMemberId(request.getId())
+                            .orElseThrow(() -> new CustomException(ErrorType.LOGIN_FAILED));
+
+        System.out.println("입력 비번: " + request.getPassword());
+        System.out.println("DB 비번: " + member.getPassword());
+        System.out.println("비교 결과: " + passwordEncoder.matches(request.getPassword(), member.getPassword()));
+
+
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new CustomException(ErrorType.LOGIN_FAILED);
+        }
+
+        UserAuthentication authentication = UserAuthentication.createUserAuthentication(member.getId());
+        String accessToken = jwtTokenProvider.issueAccessToken(authentication);
+
+        return new LoginResponseDto(accessToken);
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -25,11 +25,6 @@ public class MemberService {
         Member member = memberRepository.findByMemberId(request.getId())
                             .orElseThrow(() -> new CustomException(ErrorType.LOGIN_FAILED));
 
-        System.out.println("입력 비번: " + request.getPassword());
-        System.out.println("DB 비번: " + member.getPassword());
-        System.out.println("비교 결과: " + passwordEncoder.matches(request.getPassword(), member.getPassword()));
-
-
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new CustomException(ErrorType.LOGIN_FAILED);
         }

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.smartcampus.smartcampus_be.global.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+/**
+ * 사용자가 인증은 되었지만 특정 자원에 접근할 권한이 없는 경우
+ * Spring Security가 이 핸들러를 호출하여 적절한 JSON 응답을 클라이언트에게 반환
+ */
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403 Forbidden 상태 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<?> apiResponse = ApiResponse.error(ErrorType.ACCESS_DENIED);
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}
+

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.smartcampus.smartcampus_be.global.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인증되지 않은 사용자가 보호된 리소스에 접근하려 할 때 호출
+ * (ex. JWT 토큰이 없거나 유효하지 않은 경우)
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized 상태 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<?> apiResponse = ApiResponse.error(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.smartcampus.smartcampus_be.global.exception.CustomException;
+import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.smartcampus.smartcampus_be.global.common.jwt.JwtValidationType.VALID_JWT;
+
+/**
+ * 매 요청마다 실행되는 필터
+ * JWT 토큰을 추출하고 유효성을 검증하여 인증 처리
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            // Authorization 헤더에서 JWT 토큰 추출
+            final String token = getJwtFromRequest(request);
+
+            // 토큰이 유효한 경우
+            if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
+                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+
+                UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+            filterChain.doFilter(request, response);
+
+        } catch (Exception exception) {
+            throw new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+
+    }
+
+    // 요청 header에서 Bearer 토큰 추출
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,85 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성, 검증, 파싱 등의 기능을 제공하는 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String USER_ID = "userId";
+
+    // 액세스 토큰 유효 시간 -> 14일
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+    // 인증 정보를 기반으로 액세스 토큰 발급
+    public String issueAccessToken(final Authentication authentication) {
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+
+    // JWT 토큰 생성
+    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                                  .setIssuedAt(now)
+                                  .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
+
+        claims.put(USER_ID, authentication.getPrincipal());
+
+        return Jwts.builder()
+                   .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                   .setClaims(claims) // Claim
+                   .signWith(getSigningKey()) // Signature
+                   .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용
+    }
+
+    // 토큰 유효성 검증 (형식, 만료 등 확인)
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                   .setSigningKey(getSigningKey())
+                   .build()
+                   .parseClaimsJws(token)
+                   .getBody();
+    }
+
+    // 토큰에서 사용자 id 추출
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(USER_ID).toString());
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/JwtValidationType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/JwtValidationType.java
@@ -1,0 +1,10 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/PrincipalHandler.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/PrincipalHandler.java
@@ -1,0 +1,33 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+import org.smartcampus.smartcampus_be.global.exception.CustomException;
+import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 현재 인증된 사용자의 Principal에서 사용자 ID 추출
+ */
+@Component
+public class PrincipalHandler {
+
+    // 서 인증되지 않은 사용자의 기본 principal 값
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
+    // SecurityContext에서 Principal을 꺼내 사용자 ID로 반환
+    // 인증되지 않은 사용자는 예외 발생
+    public Long getUserIdFromPrincipal() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        isPrincipalNull(principal);
+        return Long.valueOf(principal.toString());
+    }
+
+    // principal이 anonymousUser인 경우 인증되지 않은 사용자로 간주하고 예외 발생
+    public void isPrincipalNull(
+        final Object principal
+    ) {
+        if (principal.toString().equals(ANONYMOUS_USER)) {
+            throw new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/SecurityConfig.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/SecurityConfig.java
@@ -1,0 +1,58 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+
+/**
+ * Spring Security 설정 클래스
+ * JWT 기반 인증과 예외 처리를 위한 설정 포함
+ */
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    // 인증 없이 접근 가능한 URI
+    private static final String[] AUTH_WHITE_LIST = {"/api/login"};
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .requestCache(RequestCacheConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .exceptionHandling(exception ->
+            {
+                exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                exception.accessDeniedHandler(customAccessDeniedHandler);
+            });
+
+
+        http.authorizeHttpRequests(auth -> {
+                auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                auth.anyRequest().authenticated();
+            })
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    // 비밀번호 암호화를 위한 BCryptPasswordEncoder Bean 등록
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/UserAuthentication.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/UserAuthentication.java
@@ -1,0 +1,21 @@
+package org.smartcampus.smartcampus_be.global.common.jwt;
+
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * 사용자 인증 정보를 담는 커스텀 인증 객체
+ */
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static UserAuthentication createUserAuthentication(Long userId) {
+        return new UserAuthentication(userId, null, null);
+    }
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/global/exception/ErrorType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/exception/ErrorType.java
@@ -15,6 +15,16 @@ public enum ErrorType {
     REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
 
     /**
+     * HTTP 401 (UNAUTHORIZED)
+     */
+    JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "사용자의 로그인 검증을 실패했습니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    /**
+     * HTTP 403 (FORBIDDEN)
+     */
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    /**
      * HTTP 500 (INTERNAL SERVER ERROR)
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다."),

--- a/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
@@ -13,7 +13,7 @@ public enum SuccessType {
      * HTTP 200 OK
      */
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
-    ;
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
@@ -13,7 +13,8 @@ public enum SuccessType {
      * HTTP 200 OK
      */
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
-    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다.");
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
- 로그인 / 로그아웃 API 구현
- JWT 기반 인증 처리 

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
#### 로그인 / 로그아웃 API
- `POST /api/login`
  - 로그인 성공 시 JWT accessToken 발급
- `POST /api/log-out`
  - 프론트에서 토큰 제거
 
####  JWT 인증 
- JwtTokenProvider
- JwtAuthenticationFilter
- UserAuthentication
- PrincipalHandler
- JwtValidationType

####  보안 설정
- SecurityConfig
  - /api/login 인증 없이 접근 허용

####  예외 
- CustomJwtAuthenticationEntryPoint
- CustomAccessDeniedHandler

#### Entity, DTO, Repository
- Member
- Role
  - 권한(ADMIN, USER)
- LoginRequestDto, LoginResponseDto
- MemberRepository
- MemberService

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
1. 로그인 성공 (/api/login)
<img width="1357" height="762" alt="image" src="https://github.com/user-attachments/assets/26e23eaf-63bf-4fc6-8762-518b283feec8" />

2. 로그인 실패 (아이디 or 비밀번호 틀림)
<img width="1355" height="752" alt="image" src="https://github.com/user-attachments/assets/78e93c14-e8ac-4aaf-b4e9-98fa68ba655f" />

<img width="1357" height="743" alt="image" src="https://github.com/user-attachments/assets/c1960500-48fe-407c-8b73-030811a2b3af" />

3. 로그아웃 성공 (/api/log-out)
<img width="1358" height="662" alt="image" src="https://github.com/user-attachments/assets/8e236bbb-bd18-4200-b5fc-ab10372d94dc" />

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
- DB가 확실히 안 정해져서 일단은 MySQL 로 테스트를 진행하였습니다
<img width="1220" height="191" alt="image" src="https://github.com/user-attachments/assets/384c1d00-012a-49a3-bdd9-0ca79f6b6e58" />

- 추후에 관리자 1명을 수동으로 DB에 미리 등록해두고
  → 그래야 최초 권한을 가진 사용자가 다른 여러 계정도 관리자 등록을 할 수 있을 것 같습니다! 

- 현재는 access token만 사용하는 구조인데 추후 refresh token도 사용하는 게 좋을지 의견 부탁드립니다!

- 질문이나 피드백 할 부분이 있다면 남겨주세요 🙇‍♀️