### PR TITLE
[FEAT] 관리자 계정 등록 API 구현

### DIFF
--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -12,6 +12,7 @@ import org.smartcampus.smartcampus_be.global.response.ApiResponse;
 import org.smartcampus.smartcampus_be.global.response.SuccessType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +35,7 @@ public class MemberController {
         return ResponseEntity.ok((ApiResponse<String>) ApiResponse.success(SuccessType.LOGOUT_SUCCESS));
     }
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/members")
     public ResponseEntity<ApiResponse<MemberCreateResponseDto>> createMember(@RequestBody @Valid MemberCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(SuccessType.MEMBER_CREATE_SUCCESS, memberService.createMember(request))

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -5,9 +5,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
 import org.smartcampus.smartcampus_be.domain.member.dto.LoginResponseDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateRequestDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateResponseDto;
 import org.smartcampus.smartcampus_be.domain.member.service.MemberService;
 import org.smartcampus.smartcampus_be.global.response.ApiResponse;
 import org.smartcampus.smartcampus_be.global.response.SuccessType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +32,12 @@ public class MemberController {
     @PostMapping("/log-out")
     public ResponseEntity<ApiResponse<String>> logout(HttpServletRequest request) {
         return ResponseEntity.ok((ApiResponse<String>) ApiResponse.success(SuccessType.LOGOUT_SUCCESS));
+    }
+
+    @PostMapping("/members")
+    public ResponseEntity<ApiResponse<MemberCreateResponseDto>> createMember(@RequestBody @Valid MemberCreateRequestDto request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(SuccessType.MEMBER_CREATE_SUCCESS, memberService.createMember(request))
+        );
     }
 }
 

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberCreateRequestDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberCreateRequestDto.java
@@ -1,0 +1,28 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberCreateRequestDto {
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    @Size(min = 6, max = 20, message = "아이디는 6~20자 사이여야 합니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}:;\"'<>,.?/]).{8,20}$",
+        message = "비밀번호는 영어, 숫자, 특수기호를 포함해 8~20자여야 합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "계정명은 필수입니다.")
+    private String name;
+
+    private String description;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberCreateResponseDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberCreateResponseDto.java
@@ -1,0 +1,10 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberCreateResponseDto {
+    private Long id;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -3,7 +3,10 @@ package org.smartcampus.smartcampus_be.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
 import org.smartcampus.smartcampus_be.domain.member.dto.LoginResponseDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateRequestDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateResponseDto;
 import org.smartcampus.smartcampus_be.domain.member.entity.Member;
+import org.smartcampus.smartcampus_be.domain.member.entity.Role;
 import org.smartcampus.smartcampus_be.domain.member.repository.MemberRepository;
 import org.smartcampus.smartcampus_be.global.common.jwt.JwtTokenProvider;
 import org.smartcampus.smartcampus_be.global.common.jwt.UserAuthentication;
@@ -33,5 +36,22 @@ public class MemberService {
         String accessToken = jwtTokenProvider.issueAccessToken(authentication);
 
         return new LoginResponseDto(accessToken);
+    }
+
+    public MemberCreateResponseDto createMember(MemberCreateRequestDto request) {
+
+        if (memberRepository.findByUsername(request.getUsername()).isPresent()) {
+            throw new CustomException(ErrorType.DUPLICATE_USERNAME);
+        }
+
+        Member member = Member.builder()
+                            .username(request.getUsername())
+                            .password(passwordEncoder.encode(request.getPassword()))
+                            .name(request.getName())
+                            .description(request.getDescription())
+                            .role(Role.ADMIN) //등록시 관리자 권한 주도록 고정
+                            .build();
+
+        return new MemberCreateResponseDto(memberRepository.save(member).getId());
     }
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -9,11 +9,15 @@ import org.smartcampus.smartcampus_be.domain.member.entity.Member;
 import org.smartcampus.smartcampus_be.domain.member.entity.Role;
 import org.smartcampus.smartcampus_be.domain.member.repository.MemberRepository;
 import org.smartcampus.smartcampus_be.global.common.jwt.JwtTokenProvider;
+import org.smartcampus.smartcampus_be.global.common.jwt.PrincipalHandler;
 import org.smartcampus.smartcampus_be.global.common.jwt.UserAuthentication;
 import org.smartcampus.smartcampus_be.global.exception.CustomException;
 import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final PrincipalHandler principalHandler;
 
     public LoginResponseDto login(LoginRequestDto request) {
 
@@ -38,7 +43,12 @@ public class MemberService {
         return new LoginResponseDto(accessToken);
     }
 
+    @Transactional
     public MemberCreateResponseDto createMember(MemberCreateRequestDto request) {
+
+        // db에 요청하는 사람이 있는지
+        Member requester = memberRepository.findById(principalHandler.getUserIdFromPrincipal())
+                               .orElseThrow(() -> new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION));
 
         if (memberRepository.findByUsername(request.getUsername()).isPresent()) {
             throw new CustomException(ErrorType.DUPLICATE_USERNAME);

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/PrincipalHandler.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/PrincipalHandler.java
@@ -2,6 +2,7 @@ package org.smartcampus.smartcampus_be.global.common.jwt;
 
 import org.smartcampus.smartcampus_be.global.exception.CustomException;
 import org.smartcampus.smartcampus_be.global.exception.ErrorType;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
@@ -11,23 +12,42 @@ import org.springframework.stereotype.Component;
 @Component
 public class PrincipalHandler {
 
-    // 서 인증되지 않은 사용자의 기본 principal 값
+    // 인증되지 않은 사용자의 기본 principal 값
     private static final String ANONYMOUS_USER = "anonymousUser";
 
     // SecurityContext에서 Principal을 꺼내 사용자 ID로 반환
     // 인증되지 않은 사용자는 예외 발생
     public Long getUserIdFromPrincipal() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Authentication authentication = getAuthenticationOrThrow();
+
+        Object principal = authentication.getPrincipal();
         isPrincipalNull(principal);
-        return Long.valueOf(principal.toString());
+
+        if (principal instanceof Long l) return l;
+        if (principal instanceof Integer i) return i.longValue();
+        if (principal instanceof String s) {
+            try { return Long.valueOf(s); }
+            catch (NumberFormatException e) {
+                throw new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
+            }
+        }
+
+        throw new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
     }
 
     // principal이 anonymousUser인 경우 인증되지 않은 사용자로 간주하고 예외 발생
-    public void isPrincipalNull(
-        final Object principal
-    ) {
-        if (principal.toString().equals(ANONYMOUS_USER)) {
+    public void isPrincipalNull(final Object principal) {
+        if (principal == null || ANONYMOUS_USER.equals(principal.toString())) {
             throw new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
         }
+    }
+
+    // Authentication null/미인증 방어
+    private Authentication getAuthenticationOrThrow() {
+        var context = SecurityContextHolder.getContext();
+        if (context == null || context.getAuthentication() == null || !context.getAuthentication().isAuthenticated()) {
+            throw new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+        return context.getAuthentication();
     }
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/SecurityConfig.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/common/jwt/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.smartcampus.smartcampus_be.global.common.jwt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,6 +20,7 @@ import org.springframework.security.config.annotation.web.configurers.RequestCac
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/org/smartcampus/smartcampus_be/global/exception/ErrorType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/exception/ErrorType.java
@@ -19,10 +19,16 @@ public enum ErrorType {
      */
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "사용자의 로그인 검증을 실패했습니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+
     /**
      * HTTP 403 (FORBIDDEN)
      */
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    /**
+     * HTTP 409 (CONFLICT)
+     */
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
 
     /**
      * HTTP 500 (INTERNAL SERVER ERROR)

--- a/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
@@ -14,7 +14,8 @@ public enum SuccessType {
      */
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
-    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다.");
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
+    MEMBER_CREATE_SUCCESS(HttpStatus.CREATED, "관리자 계정 등록에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
- 관리자 계정 등록 API 구현

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- `MemberController` -> Post /api/members 추가
- `MemberCreateRequestDto`, `MemberCreateResponseDto`
  - MemberCreateRequestDTo에 아이디, 비밀번호 조건 검증하도록 구현
  - <img width="313" height="167" alt="image" src="https://github.com/user-attachments/assets/af7a7dca-16c3-4ef8-a2e5-f1cb95627ca7" />

- `MemberSerivce` -> 관리자 등록 로직 

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
1. 관리자 등록 성공

<img width="480" alt="image" src="https://github.com/user-attachments/assets/7fe23896-c0c4-4a40-b8cf-9cc773ba8c6e">

<img width="520" alt="image" src="https://github.com/user-attachments/assets/56d76c13-cdce-4315-a9cc-4b14ea88ee24">

> 이름은 동명이인이 있을 수도 있으니까 같게 가능  

<br><br>

2. 관리자 등록 실패 (아이디, 비밀번호 조건 맞지 않을 경우)

<img width="480" alt="image" src="https://github.com/user-attachments/assets/b683a834-d952-4ebb-a06f-9565ae99e33c">

> 길이 충족 X, 숫자 1개라도 X, 특수기호 1개라도 X, 영어 1개라도 X — 모두 테스트 완료  

<br><br>


3. 관리자 등록 실패 (아이디가 같을 경우)

<img width="480" alt="image" src="https://github.com/user-attachments/assets/aee4c937-176c-4aa9-b3d8-459eef54d515">

<br><br>

4. 관리자 등록 실패 (db에 존재하는 계정이 아닌 사람이 등록하거나 잘못된 accesstoken인 경우)
<img width="480" height="728" alt="image" src="https://github.com/user-attachments/assets/8c6e09da-797c-49dd-8a06-8c73579eeb4c" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
- 관리자 등록 시 이미 관리자인 사람만이 등록할 수 있도록 하는 것이 괜찮을까요 ?!