### PR TITLE
[FEAT] 관리자 계정 수정 API 구현

### DIFF
--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -3,20 +3,14 @@ package org.smartcampus.smartcampus_be.domain.member.Controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
-import org.smartcampus.smartcampus_be.domain.member.dto.LoginResponseDto;
-import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateRequestDto;
-import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateResponseDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.*;
 import org.smartcampus.smartcampus_be.domain.member.service.MemberService;
 import org.smartcampus.smartcampus_be.global.response.ApiResponse;
 import org.smartcampus.smartcampus_be.global.response.SuccessType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,6 +34,13 @@ public class MemberController {
     public ResponseEntity<ApiResponse<MemberCreateResponseDto>> createMember(@RequestBody @Valid MemberCreateRequestDto request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(SuccessType.MEMBER_CREATE_SUCCESS, memberService.createMember(request))
         );
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/members/{id}")
+    public ResponseEntity<ApiResponse<String>> updateMember(@PathVariable Long id, @RequestBody @Valid MemberUpdateRequestDto request) {
+        memberService.updateMember(id, request);
+        return ResponseEntity.ok((ApiResponse<String>)ApiResponse.success(SuccessType.MEMBER_UPDATE_SUCCESS));
     }
 }
 

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateRequestDto {
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}:;\"'<>,.?/]).{8,20}$",
+        message = "비밀번호는 영어, 숫자, 특수기호를 포함해 8~20자여야 합니다."
+    )
+    private String password; // ✅ 여기에 붙여야 해요
+
+    @NotBlank(message = "계정명은 필수입니다.")
+    private String name;
+
+    private String description;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberUpdateRequestDto.java
@@ -14,7 +14,7 @@ public class MemberUpdateRequestDto {
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}:;\"'<>,.?/]).{8,20}$",
         message = "비밀번호는 영어, 숫자, 특수기호를 포함해 8~20자여야 합니다."
     )
-    private String password; // ✅ 여기에 붙여야 해요
+    private String password;
 
     @NotBlank(message = "계정명은 필수입니다.")
     private String name;

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Member.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/entity/Member.java
@@ -29,4 +29,10 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    public void update(String password, String name, String description) {
+        this.password = password;
+        this.name = name;
+        this.description = description;
+    }
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -1,10 +1,7 @@
 package org.smartcampus.smartcampus_be.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
-import org.smartcampus.smartcampus_be.domain.member.dto.LoginRequestDto;
-import org.smartcampus.smartcampus_be.domain.member.dto.LoginResponseDto;
-import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateRequestDto;
-import org.smartcampus.smartcampus_be.domain.member.dto.MemberCreateResponseDto;
+import org.smartcampus.smartcampus_be.domain.member.dto.*;
 import org.smartcampus.smartcampus_be.domain.member.entity.Member;
 import org.smartcampus.smartcampus_be.domain.member.entity.Role;
 import org.smartcampus.smartcampus_be.domain.member.repository.MemberRepository;
@@ -13,8 +10,6 @@ import org.smartcampus.smartcampus_be.global.common.jwt.PrincipalHandler;
 import org.smartcampus.smartcampus_be.global.common.jwt.UserAuthentication;
 import org.smartcampus.smartcampus_be.global.exception.CustomException;
 import org.smartcampus.smartcampus_be.global.exception.ErrorType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,5 +58,22 @@ public class MemberService {
                             .build();
 
         return new MemberCreateResponseDto(memberRepository.save(member).getId());
+    }
+
+    @Transactional
+    public void updateMember(Long id, MemberUpdateRequestDto request) {
+
+        Member requester = memberRepository.findById(principalHandler.getUserIdFromPrincipal())
+                               .orElseThrow(() -> new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION));
+
+        Member member = memberRepository.findById(id)
+                            .orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
+
+
+        member.update(
+            passwordEncoder.encode(request.getPassword()),
+            request.getName(),
+            request.getDescription()
+        );
     }
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/global/exception/ErrorType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/exception/ErrorType.java
@@ -26,6 +26,11 @@ public enum ErrorType {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     /**
+     *  HTTP 404 (NOT FOUND)
+     */
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
+
+    /**
      * HTTP 409 (CONFLICT)
      */
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),

--- a/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
@@ -15,7 +15,8 @@ public enum SuccessType {
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
-    MEMBER_CREATE_SUCCESS(HttpStatus.CREATED, "관리자 계정 등록에 성공했습니다.");
+    MEMBER_CREATE_SUCCESS(HttpStatus.CREATED, "관리자 계정 등록에 성공했습니다."),
+    MEMBER_UPDATE_SUCCESS(HttpStatus.OK, "관리자 계정이 수정되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
- 관리자 계정 수정 API 구현

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- `MemberController` -> Patch /api/members/{id} 추가
- `MemberUpdateRequestDto`
  - MemberUpdateRequestDTo에 비밀번호 조건 검증하도록 구현
  - 아이디는 수정 불가

- `MemberSerivce` -> 관리자 계정 수정 로직

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
1. 관리자 수정 성공

<img width="480" height="702" alt="image" src="https://github.com/user-attachments/assets/8c2b3a7d-e27b-4922-aee6-8d7ebf7339bf" />
<img width="480" height="157" alt="image" src="https://github.com/user-attachments/assets/8c258eb2-e05d-409d-85ff-c0b1d2e8fac0" />
<img width="480" height="135" alt="image" src="https://github.com/user-attachments/assets/63d9dc52-5567-4470-95e1-befa0c4e7d4c" />

<br><br>

2. 관리자 수정 실패 (비밀번호 조건 맞지 않을 경우)

<img width="480" height="780" alt="image" src="https://github.com/user-attachments/assets/843a85a4-9df0-47d2-bfe5-cbaf03bdb590" />


> 길이 충족 X, 숫자 1개라도 X, 특수기호 1개라도 X, 영어 1개라도 X — 모두 테스트 완료  

<br><br>


3. 관리자 수정 실패 (db에 존재하는 계정이 아닌 사람이 등록하거나 잘못된 accesstoken인 경우)

<img width="480" height="712" alt="image" src="https://github.com/user-attachments/assets/cb067e71-3565-4066-b15d-3f2dc83d1bc3" />


<br><br>

4. 관리자 등록 실패 (db에 존재하는 id로 요청보내는 경우)
<img width="480" height="697" alt="image" src="https://github.com/user-attachments/assets/6053d1aa-7666-4dca-8dd2-d2ac9afaf193" />


> DB에 없는 아이디인 5로 요청 보낸 예시 

## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
- 관리자 수정 시 아이디(username)는 수정은 요청으로 받지 않도록 구현하였습니다 ! 