### PR TITLE
[FEAT] 관리자 계정 삭제 API 구현 

### DIFF
--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -42,5 +42,12 @@ public class MemberController {
         memberService.updateMember(id, request);
         return ResponseEntity.ok((ApiResponse<String>)ApiResponse.success(SuccessType.MEMBER_UPDATE_SUCCESS));
     }
+
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/members")
+    public ResponseEntity<ApiResponse<String>> deleteMembers(@RequestBody @Valid MemberDeleteRequestDto request) {
+        memberService.deleteMembers(request);
+        return ResponseEntity.ok((ApiResponse<String>)ApiResponse.success(SuccessType.MEMBER_DELETE_SUCCESS));
+    }
 }
 

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberDeleteRequestDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberDeleteRequestDto.java
@@ -1,0 +1,15 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MemberDeleteRequestDto {
+
+    @NotEmpty(message = "삭제할 계정 리스트는 필수입니다.")
+    private List<Long> ids;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -13,6 +13,7 @@ import org.smartcampus.smartcampus_be.global.exception.ErrorType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -75,5 +76,20 @@ public class MemberService {
             request.getName(),
             request.getDescription()
         );
+    }
+
+    @Transactional
+    public void deleteMembers(MemberDeleteRequestDto request) {
+
+        Member requester = memberRepository.findById(principalHandler.getUserIdFromPrincipal())
+                               .orElseThrow(() -> new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION));
+
+        List<Member> members = memberRepository.findAllById(request.getIds());
+
+        if (members.size() != request.getIds().size()) {
+            throw new CustomException(ErrorType.MEMBER_NOT_FOUND); // 일부라도 없으면 실패
+        }
+
+        memberRepository.deleteAll(members);
     }
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
@@ -16,7 +16,8 @@ public enum SuccessType {
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
     MEMBER_CREATE_SUCCESS(HttpStatus.CREATED, "관리자 계정 등록에 성공했습니다."),
-    MEMBER_UPDATE_SUCCESS(HttpStatus.OK, "관리자 계정이 수정되었습니다.");
+    MEMBER_UPDATE_SUCCESS(HttpStatus.OK, "관리자 계정이 수정되었습니다."),
+    MEMBER_DELETE_SUCCESS(HttpStatus.OK, "관리자 계정이 삭제되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
- 관리자 계정 삭제 API 구현

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- `MemberController` -> Delete /api/members 추가
- `MemberDeleteRequestDto`
- `MemberSerivce` -> 관리자 삭제 로직 

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
1. 관리자 삭제 성공

<img width="480" height="708" alt="image" src="https://github.com/user-attachments/assets/82355fb8-a756-4e15-8d08-367387f561b5" />
<img width="480" height="138" alt="image" src="https://github.com/user-attachments/assets/89e21fee-c9a8-4651-8f4b-723675287927" />
<img width="480" height="190" alt="image" src="https://github.com/user-attachments/assets/2e0b6c3e-d083-4bf5-a43c-7ee676d48d4c" />

<br><br>

2. 관리자 삭제 실패 (DB에 없는 계정으로 요청 보낸 경우)

<img width="801" height="713" alt="image" src="https://github.com/user-attachments/assets/c08ec7c2-1568-4e0a-a1d1-754fa42ac18d" /> 

<br><br>


3. 관리자 삭제 실패 (삭제할 계정 없이 요청 보낸 경우)

<img width="480" height="757" alt="image" src="https://github.com/user-attachments/assets/28c841b7-5732-4b55-9428-ebc525133b11" />



<br><br>

4. 관리자 삭제 실패 (db에 존재하는 계정이 아닌 사람이 등록하거나 잘못된 accesstoken인 경우)
<img width="480" height="702" alt="image" src="https://github.com/user-attachments/assets/a9b90939-07ef-4919-b1b3-873ec01857e4" />



## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
- 