### PR TITLE
[FEAT] 관리자 계정 조회 API 구현

### DIFF
--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/Controller/MemberController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -48,6 +50,12 @@ public class MemberController {
     public ResponseEntity<ApiResponse<String>> deleteMembers(@RequestBody @Valid MemberDeleteRequestDto request) {
         memberService.deleteMembers(request);
         return ResponseEntity.ok((ApiResponse<String>)ApiResponse.success(SuccessType.MEMBER_DELETE_SUCCESS));
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/members")
+    public ResponseEntity<ApiResponse<List<MemberListResponseDto>>> getAllMembers() {
+        return ResponseEntity.ok(ApiResponse.success(SuccessType.MEMBER_GET_SUCCESS, memberService.getAllMembers()));
     }
 }
 

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberListResponseDto.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/dto/MemberListResponseDto.java
@@ -1,0 +1,13 @@
+package org.smartcampus.smartcampus_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberListResponseDto {
+    private String username;
+    private String password;
+    private String name;
+    private String description;
+}

--- a/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/domain/member/service/MemberService.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -92,4 +93,21 @@ public class MemberService {
 
         memberRepository.deleteAll(members);
     }
+
+    @Transactional(readOnly = true)
+    public List<MemberListResponseDto> getAllMembers() {
+
+        Member requester = memberRepository.findById(principalHandler.getUserIdFromPrincipal())
+                               .orElseThrow(() -> new CustomException(ErrorType.JWT_UNAUTHORIZED_EXCEPTION));
+
+        return memberRepository.findAll().stream()
+                   .map(member -> new MemberListResponseDto(
+                       member.getUsername(),
+                       member.getPassword(),
+                       member.getName(),
+                       member.getDescription()
+                   ))
+                   .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
+++ b/src/main/java/org/smartcampus/smartcampus_be/global/response/SuccessType.java
@@ -17,7 +17,8 @@ public enum SuccessType {
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃에 성공했습니다."),
     MEMBER_CREATE_SUCCESS(HttpStatus.CREATED, "관리자 계정 등록에 성공했습니다."),
     MEMBER_UPDATE_SUCCESS(HttpStatus.OK, "관리자 계정이 수정되었습니다."),
-    MEMBER_DELETE_SUCCESS(HttpStatus.OK, "관리자 계정이 삭제되었습니다.");
+    MEMBER_DELETE_SUCCESS(HttpStatus.OK, "관리자 계정이 삭제되었습니다."),
+    MEMBER_GET_SUCCESS(HttpStatus.OK, "관리자 계정 리스트 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 이 PR이 어떤 기능을 다루는지 간략히 설명해 주세요 -->
- 관리자 계정 조회 API 구현

## 📌 구현 내용
<!-- 주요 구현 사항, 컴포넌트 설명 등을 작성해 주세요 -->
- `MemberController` -> Get /api/members 추가
- `MemberListResponseDto`
- `MemberSerivce` -> 관리자 리스트 조회 로직 

## 📌 구현 결과
<!-- UI 변경 사항이 있다면 스크린샷 포함해 주세요 -->
<!-- 작동 예시, 테스트 결과 등도 포함 가능 -->
1. 관리자 리스트 조회 성공

<img width="480" height="882" alt="image" src="https://github.com/user-attachments/assets/2edd4bef-bd0a-4b47-b7c7-bbd06e9ee684" />
<img width="480" height="152" alt="image" src="https://github.com/user-attachments/assets/d45cc821-d8da-4a7c-9740-d29be6b264b3" />


<br><br>

2. 관리자 조회 실패 (db에 존재하는 계정이 아닌 사람이 등록하거나 잘못된 accesstoken인 경우)

<img width="480" height="518" alt="image" src="https://github.com/user-attachments/assets/96e21095-bb76-4e97-91de-c8caa89b5efc" />


## 📌 논의하고 싶은 점
<!-- 리뷰어나 팀원들과 논의하고 싶은 내용을 자유롭게 작성해 주세요 -->
- 관리자 등록 시 DB에 비밀번호를 암호화하여 저장하고 있기 때문에 계정의 실제 비밀번호는 조회할 수 X
- UI 상에서는 비밀번호 값을 그대로 노출하고 있어서 이 부분은 프론트측과 의논하면 좋을 것 같습니다 ! 